### PR TITLE
Return 422 for an unprocessable demo instead of 500

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ out-monoliths/
 ### Secrets ###
 
 # End of https://www.toptal.com/developers/gitignore/api/go
+
+# Compiled binary from `go build` in this directory (name matches the module)
+/csgo-demo-worker

--- a/classify.go
+++ b/classify.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/csconfederation/demoScrape2/pkg/demoscrape2"
+)
+
+// classifyParseResult turns a ProcessDemo outcome into an HTTP status and body.
+//
+// The status is load-bearing for callers, not just for logging: CSC-Stats
+// relays it and CSC-Core counts only >=500 toward its stats circuit breaker. A
+// bad demo reported as 5xx therefore reads as "the parser is down" and
+// suppresses unrelated uploads — which is how one unparseable recording dropped
+// two of three maps from match 9077 (csconfederation/csc-issues#8). So an
+// unprocessable demo must be a 4xx, and 5xx must mean we are genuinely broken.
+func classifyParseResult(game *demoscrape2.Game, err error) (int, any) {
+	if err == nil {
+		return 200, game
+	}
+
+	switch {
+	case strings.Contains(err.Error(), "ErrInvalidFileType"):
+		// Not a demo at all — a malformed request rather than a bad recording.
+		return 400, err.Error()
+
+	case errors.Is(err, demoscrape2.ErrNoValidRounds):
+		// Checked before ErrUnexpectedEndOfDemo: a truncated demo with no rounds
+		// is both, and "nothing importable in here" is the actionable half.
+		return 422, err.Error()
+
+	case strings.Contains(err.Error(), "ErrUnexpectedEndOfDemo") && game != nil && game.Result == "Ended":
+		// Demo stream was cut short but the match had already finished, so the
+		// stats are complete. Not an error from the caller's point of view.
+		return 200, game
+
+	default:
+		return 500, err.Error()
+	}
+}

--- a/classify_test.go
+++ b/classify_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/csconfederation/demoScrape2/pkg/demoscrape2"
+)
+
+func TestClassifyParseResult(t *testing.T) {
+	game := &demoscrape2.Game{}
+	endedGame := &demoscrape2.Game{Result: "Ended"}
+
+	tests := []struct {
+		name       string
+		game       *demoscrape2.Game
+		err        error
+		wantStatus int
+	}{
+		{
+			name:       "success",
+			game:       game,
+			err:        nil,
+			wantStatus: 200,
+		},
+		{
+			// The match 9077 case: an aborted force-start recorded no rounds.
+			// Must not be a 5xx — CSC-Core reads that as an outage and stops
+			// uploading the rest of the series.
+			name:       "no valid rounds is unprocessable",
+			game:       game,
+			err:        demoscrape2.ErrNoValidRounds,
+			wantStatus: 422,
+		},
+		{
+			// ProcessDemo joins ParseToEnd's error with ErrNoValidRounds, so the
+			// sentinel arrives wrapped. errors.Is must still see through it.
+			name:       "no valid rounds wrapped in a join still classifies",
+			game:       game,
+			err:        errors.Join(errors.New("demo stream ended unexpectedly (ErrUnexpectedEndOfDemo)"), demoscrape2.ErrNoValidRounds),
+			wantStatus: 422,
+		},
+		{
+			name:       "not a demo file",
+			game:       game,
+			err:        errors.New("invalid File-Type; expecting HL2DEMO in the first 8 bytes (ErrInvalidFileType)"),
+			wantStatus: 400,
+		},
+		{
+			// Truncated stream but the match had finished: stats are complete.
+			name:       "truncated demo of a finished match still succeeds",
+			game:       endedGame,
+			err:        errors.New("demo stream ended unexpectedly (ErrUnexpectedEndOfDemo)"),
+			wantStatus: 200,
+		},
+		{
+			name:       "truncated demo of an unfinished match is a server error",
+			game:       game,
+			err:        errors.New("demo stream ended unexpectedly (ErrUnexpectedEndOfDemo)"),
+			wantStatus: 500,
+		},
+		{
+			name:       "unrecognised failure stays a server error",
+			game:       game,
+			err:        fmt.Errorf("something went wrong"),
+			wantStatus: 500,
+		},
+		{
+			// ProcessDemo is contracted to return a non-nil Game, but this path
+			// dereferences it, so don't panic if that ever stops being true.
+			name:       "nil game does not panic",
+			game:       nil,
+			err:        errors.New("demo stream ended unexpectedly (ErrUnexpectedEndOfDemo)"),
+			wantStatus: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, _ := classifyParseResult(tt.game, tt.err)
+			if status != tt.wantStatus {
+				t.Errorf("classifyParseResult() status = %d, want %d", status, tt.wantStatus)
+			}
+		})
+	}
+}
+
+// ErrNoValidRounds must never be classified as 5xx: that is exactly the
+// misclassification that made a single bad demo look like a stats-API outage.
+func TestNoValidRoundsIsNever5xx(t *testing.T) {
+	for _, err := range []error{
+		demoscrape2.ErrNoValidRounds,
+		errors.Join(errors.New("demo stream ended unexpectedly (ErrUnexpectedEndOfDemo)"), demoscrape2.ErrNoValidRounds),
+		fmt.Errorf("wrapped: %w", demoscrape2.ErrNoValidRounds),
+	} {
+		status, _ := classifyParseResult(&demoscrape2.Game{}, err)
+		if status >= 500 {
+			t.Errorf("classifyParseResult(%v) = %d, must not be 5xx", err, status)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/martig3/csgo-demo-worker
 go 1.25.7
 
 require (
-	github.com/csconfederation/demoScrape2 v0.3.1-0.20260716133354-616f85b5f81e
+	github.com/csconfederation/demoScrape2 v0.3.1
 	github.com/gin-gonic/gin v1.9.1
 	github.com/sirupsen/logrus v1.9.4
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/martig3/csgo-demo-worker
 go 1.25.7
 
 require (
-	github.com/csconfederation/demoScrape2 v0.2.19
+	github.com/csconfederation/demoScrape2 v0.3.1-0.20260716133354-616f85b5f81e
 	github.com/gin-gonic/gin v1.9.1
 	github.com/sirupsen/logrus v1.9.4
 )

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,8 @@ github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZX
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
-github.com/csconfederation/demoScrape2 v0.2.19 h1:j4lNKQhxUVAQxPaa4mEVBi5g02/Hv1Y+eR1ILojXUGQ=
-github.com/csconfederation/demoScrape2 v0.2.19/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
-github.com/csconfederation/demoScrape2 v0.3.1-0.20260716133354-616f85b5f81e h1:h9jyPaa57hgG2L9Y+g4QKEkEAD5rvj1Kb1Cu3B0CykM=
-github.com/csconfederation/demoScrape2 v0.3.1-0.20260716133354-616f85b5f81e/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
+github.com/csconfederation/demoScrape2 v0.3.1 h1:lnufO6FiyLY7/EGfJ9xcaxj3fPQ8cH/b1GDHA+QGcBY=
+github.com/csconfederation/demoScrape2 v0.3.1/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhD
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
 github.com/csconfederation/demoScrape2 v0.2.19 h1:j4lNKQhxUVAQxPaa4mEVBi5g02/Hv1Y+eR1ILojXUGQ=
 github.com/csconfederation/demoScrape2 v0.2.19/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
+github.com/csconfederation/demoScrape2 v0.3.1-0.20260716133354-616f85b5f81e h1:h9jyPaa57hgG2L9Y+g4QKEkEAD5rvj1Kb1Cu3B0CykM=
+github.com/csconfederation/demoScrape2 v0.3.1-0.20260716133354-616f85b5f81e/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/csconfederation/demoScrape2/pkg/demoscrape2"
@@ -38,18 +37,8 @@ func main() {
 			return
 		}
 		var game, err = demoscrape2.ProcessDemo(c.Request.Body)
-		if err != nil {
-			if strings.Contains(err.Error(), "ErrInvalidFileType") {
-				c.JSON(400, err.Error())
-				return
-			} else if strings.Contains(err.Error(), "ErrUnexpectedEndOfDemo") && game.Result == "Ended" {
-				c.JSON(200, game)
-				return
-			}
-			c.JSON(500, err.Error())
-			return
-		}
-		c.JSON(200, game)
+		status, body := classifyParseResult(game, err)
+		c.JSON(status, body)
 	})
 	api.GET("/parse-remote", func(c *gin.Context) {
 		url := c.Query("url")
@@ -83,18 +72,8 @@ func main() {
 			return
 		}
 		var game, err = demoscrape2.ProcessDemo(c.Request.Body)
-		if err != nil {
-			if strings.Contains(err.Error(), "ErrInvalidFileType") {
-				c.JSON(400, err.Error())
-				return
-			} else if strings.Contains(err.Error(), "ErrUnexpectedEndOfDemo") && game.Result == "Ended" {
-				c.JSON(200, game)
-				return
-			}
-			c.JSON(500, err.Error())
-			return
-		}
-		c.JSON(200, game)
+		status, body := classifyParseResult(game, err)
+		c.JSON(status, body)
 	})
 	err := r.Run()
 	if err != nil {


### PR DESCRIPTION
> **Draft — blocked.** `go.mod` points at a demoScrape2 **pseudo-version from the branch** of csconfederation/demoScrape2#25 (`v0.3.1-0.20260716133354-616f85b5f81e`). That PR must merge **and be tagged**, then this needs re-pointing at the real tag before it can merge. Everything else here is ready for review.

## Why

An unparseable demo came back 500, which callers cannot distinguish from the parser being down. That distinction is load-bearing: CSC-Stats relays this status, and CSC-Core counts **only >=500** toward its stats circuit breaker.

On 2026-07-14 a demo with zero completed rounds (an aborted force-start) panicked the parser here — gin's Recovery turned it into `[GIN] 500 | POST "/api/parse"` — CSC-Core read that as an outage, opened the breaker, and the two maps queued behind it were **never uploaded at all**. A BO3 series kept only map 1's stats. Reported as csconfederation/csc-issues#8; full chain in ehwhattaugonnado/Core-planning#146.

Two problems in the old classifier, both fixed here:

1. **A panic bypassed it entirely** — fixed upstream in demoScrape2#25, which returns `ErrNoValidRounds` instead of panicking.
2. **`default: 500`** — any unrecognised parse failure was reported as a server fault even when the server is fine and the *input* is bad.

## What

`ErrNoValidRounds` → **422**. Checked *before* the `ErrUnexpectedEndOfDemo` case: a truncated demo with no rounds is both, and "there's nothing importable in here" is the actionable half. 422 rather than 400 keeps it distinct from the malformed-*request* cases already using 400 (empty body, bad URL).

## The refactor, and why it's in scope

`/api/parse` and `/api/parse-remote` carried **byte-identical copies** of the classification block — a fix had to be made twice and could silently be made once. It's also the only part worth testing, and pulling it out of the handler means it can be tested **without a demo fixture**, which is otherwise the blocker for covering any of this. Hence `classifyParseResult(game, err) (int, any)`.

Happy to inline it back if you'd rather keep the diff to the mapping alone, but the duplication is what made me nervous about touching only one copy.

## Testing

`gofmt -l`, `go build`, `go vet`, `go test ./...` all clean (via `golang:1.25` — no Go toolchain on the dev box). These are the repo's first tests.

Covered: success, `ErrNoValidRounds` bare / joined / `%w`-wrapped (the sentinel arrives **joined** with `ParseToEnd`'s error from demoScrape2#25, so `errors.Is` seeing through the join is the thing that actually has to hold), `ErrInvalidFileType` → 400, truncated-but-finished → 200, truncated-unfinished → 500, unrecognised → 500, and a nil `Game` (that path dereferences `game.Result`; `ProcessDemo` is contracted to return non-nil, but the test pins it).

There's an explicit test that `ErrNoValidRounds` is **never** 5xx in any wrapping — that's the exact misclassification that caused the incident.

**Verified against the real production demo.** Match 9077's actual poison file was pulled from S3 and run through `ProcessDemo` (on demoScrape2#25) with this PR's classifier applied:

```
HTTP 422  ...mid9077-0_de_inferno-2026-07-14_04-03-43.dem   map=de_inferno rounds=0 isNoValidRounds=true
```

`rounds=0` — the aborted force-start really did record zero rounds. The same file against unfixed demoScrape2 `main` still panics, and the series' three good maps classify 200 (`rounds=30/29/19`, matching CSC-Core's recorded scores), so the sentinel doesn't misfire on valid recordings. Detail in the comment below.

Still not verified: a live end-to-end run of the full worker → CSC-Stats → CSC-Core chain.

## Note

The module path is `github.com/martig3/csgo-demo-worker` despite the repo living under `csconfederation/`. Left alone deliberately — not a drive-by worth the dependency churn.

Closes ehwhattaugonnado/Core-planning#148
Part of ehwhattaugonnado/Core-planning#146

**Reviewers:** ehwhattaugonnado/Core-planning#151 is the review handoff for this four-repo family — full scope, decisions to scrutinise, verification status, and merge order. This PR is #2 of 4 in the suggested reading order, and the only one with a hard blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
