### PR TITLE
Bump demoScrape2 to v0.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/martig3/csgo-demo-worker
 go 1.25.7
 
 require (
-	github.com/csconfederation/demoScrape2 v0.3.1
+	github.com/csconfederation/demoScrape2 v0.3.2
 	github.com/gin-gonic/gin v1.9.1
 	github.com/sirupsen/logrus v1.9.4
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bytedance/sonic v1.9.1/go.mod h1:i736AoUSYt75HyZLoJW9ERYxcy6eaN6h4BZX
 github.com/chenzhuoyu/base64x v0.0.0-20211019084208-fb5309c8db06/go.mod h1:DH46F32mSOjUmXrMHnKwZdA8wcEefY7UVqBKYGjpdQY=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 h1:qSGYFH7+jGhDF8vLC+iwCD4WpbV1EBDSzWkJODFLams=
 github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311/go.mod h1:b583jCggY9gE99b6G5LEC39OIiVsWj+R97kbl5odCEk=
-github.com/csconfederation/demoScrape2 v0.3.1 h1:lnufO6FiyLY7/EGfJ9xcaxj3fPQ8cH/b1GDHA+QGcBY=
-github.com/csconfederation/demoScrape2 v0.3.1/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
+github.com/csconfederation/demoScrape2 v0.3.2 h1:CYtyHd8x7/XL8us6wRNoe1HQQcHh+w7bS4AiBpn9m98=
+github.com/csconfederation/demoScrape2 v0.3.2/go.mod h1:wNoT9JKua6X6/CmMiu64E1y7+P5ecM+oLz9BLFvAv3Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
## Summary

- consume demoScrape2 v0.3.2
- ship exact string transport for every Steam64-bearing parser field

## Why

Steam64 identifiers exceed JavaScript's safe integer range. The parser module now emits them as decimal JSON strings so CSC-Stats can decode them to bigint without precision loss.

This is the required producer deployment before strict CSC-Stats decoding in csconfederation/CSC-Stats#70.

Related to ehwhattaugonnado/Core-planning#154.

## Validation

- `go mod tidy`
- `go test ./...`
- parsed and ingested the supplied Anubis, Ancient, and Inferno demos through the local worker and Stats stack
- zero malformed Steam64 values, ownership mismatches, unresolved identities, or logical duplicates
