### PR TITLE
ci: don't pin runner to monkas label

### DIFF
--- a/.github/workflows/csgo-demo-worker-pipeline.yml
+++ b/.github/workflows/csgo-demo-worker-pipeline.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   detect-changes:
-    runs-on: [self-hosted, monkas]
+    runs-on: self-hosted
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:


### PR DESCRIPTION
## Summary
- Changes `runs-on: [self-hosted, monkas]` to `runs-on: self-hosted` in `csgo-demo-worker-pipeline.yml` so CI jobs can run on any available self-hosted runner instead of being pinned to the single `monkas`-labeled runner.
- SPOF-avoidance cleanup only — no functional change to the pipeline.

## Test plan
- [x] Verified the workflow YAML still parses (single-line change, no other `runs-on` occurrences in the file)